### PR TITLE
package json imporvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "postinstall": "bower install",
     "lint": "jshint **.js",
-    "start": "concurrently 'nodemon' 'gulp'"
+    "start": "concurrently --kill-others --raw 'nodemon' 'gulp'"
   },
   "keywords": [
     "deals"


### PR DESCRIPTION
Added --kill-others to npm start script which will kill all commands if one fails which should should with the node address in use problems we've been having. The --raw additon just makes the lines look a bit nicer.
